### PR TITLE
🔧 Remove deprecated option

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,12 +96,9 @@ testlogger {
     logLevel = LogLevel.LIFECYCLE
 }
 
-// Use new JVM IR backend (yolo).
-// https://blog.jetbrains.com/kotlin/2021/02/the-jvm-backend-is-in-beta-let-s-make-it-stable-together
-// Also set JVM target.
+// Set JVM target.
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
-        useIR = true
         jvmTarget = "13"
     }
 }


### PR DESCRIPTION
"'useIR: Boolean' is deprecated. This option has no effect and will be removed in a future release." 
    - IntelliJ