### PR TITLE
✨ Add sending via email templates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,10 @@ dependencies {
     implementation("io.ktor:ktor-gson:$ktor_version")
     implementation("io.ktor:ktor-auth:$ktor_version")
     implementation("io.ktor:ktor-freemarker:$ktor_version")
+    implementation("io.ktor:ktor-client-core:$ktor_version")
+    implementation("io.ktor:ktor-client-cio:$ktor_version")
+    implementation("io.ktor:ktor-client-logging:$ktor_version")
+    implementation("io.ktor:ktor-client-gson:$ktor_version")
 
     implementation("ch.qos.logback:logback-classic:$logback_version")
 
@@ -55,8 +59,6 @@ dependencies {
     implementation("guru.zoroark:ktor-rate-limit:$ktor_rate_limit_version")
 
     implementation("org.flywaydb:flyway-core:$flyway_version")
-
-    implementation("com.sendgrid:sendgrid-java:$sendgrid_version")
 
     testImplementation("io.ktor:ktor-server-tests:$ktor_version")
 

--- a/scripts/submit_registration
+++ b/scripts/submit_registration
@@ -73,5 +73,5 @@ curl --verbose \
       "slug": "'"${slug}"'",
       "terms": '"${terms}"',
       "answers": '"${qa}"',
-      "type": '"${happening}"' }' \
+      "type": "'"${happening}"'" }' \
   "$host":"$port"/registration

--- a/src/main/kotlin/no/uib/echo/Application.kt
+++ b/src/main/kotlin/no/uib/echo/Application.kt
@@ -1,6 +1,5 @@
 package no.uib.echo
 
-import com.sendgrid.SendGrid
 import freemarker.cache.ClassTemplateLoader
 import io.ktor.application.*
 import io.ktor.features.CORS
@@ -75,9 +74,7 @@ fun Application.module() {
     if (sendGridApiKey == null && System.getenv("DEV") == null && (sendEmailReg || sendEmailHap))
         throw Exception("SENDGRID_API_KEY not defined in non-dev environment, with SEND_EMAIL_REGISTRATION = $sendEmailReg and SEND_EMAIL_HAPPENING = $sendEmailHap.")
 
-    val sendGrid = if (sendGridApiKey == null) null else SendGrid(sendGridApiKey)
-
     Db.init()
-    configureRouting(adminKey, sendGrid, FeatureToggles(sendEmailReg = sendEmailReg, sendEmailHap = sendEmailHap))
+    configureRouting(adminKey, sendGridApiKey, FeatureToggles(sendEmailReg = sendEmailReg, sendEmailHap = sendEmailHap))
 }
 

--- a/src/main/kotlin/no/uib/echo/Email.kt
+++ b/src/main/kotlin/no/uib/echo/Email.kt
@@ -1,34 +1,99 @@
 package no.uib.echo
 
-import com.sendgrid.Method
-import com.sendgrid.Request
-import com.sendgrid.SendGrid
-import com.sendgrid.helpers.mail.Mail
-import com.sendgrid.helpers.mail.objects.Content
-import com.sendgrid.helpers.mail.objects.Email
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.features.json.GsonSerializer
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.logging.Logging
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import no.uib.echo.schema.RegistrationJson
 import java.io.IOException
 
-fun sendEmail(from: String, to: String, subject: String, body: String, sendGrid: SendGrid): Boolean {
-    val confirmationMail = Mail(
-        Email(from),
-        subject,
-        Email(to),
-        Content("text/plain", body)
-    )
-    val req = Request()
-    try {
-        req.method = Method.POST
-        req.endpoint = "mail/send"
-        req.body = confirmationMail.build()
-        val response = sendGrid.api(req)
+data class SendGridRequest(
+    val personalizations: List<SendGridPersonalization>,
+    val from: SendGridEmail,
+    val template_id: String
+)
 
-        if (response.statusCode != 202) {
-            throw IOException("Status code is not 202: ${response.statusCode}, ${response.body}")
-        }
-    } catch (e: IOException) {
-        e.printStackTrace()
-        return false
+data class SendGridPersonalization(val to: List<SendGridEmail>, val dynamic_template_data: SendGridTemplate)
+
+data class SendGridTemplate(
+    val title: String,
+    val link: String,
+    val hapTypeLiteral: String,
+    val waitListSpot: Int? = null,
+    val registration: RegistrationJson? = null
+)
+
+data class SendGridEmail(val email: String, val name: String? = null)
+
+enum class Template {
+    CONFIRM_REG,
+    CONFIRM_WAIT,
+    REGS_LINK
+}
+
+private const val SENDGRID_ENDPOINT = "https://api.sendgrid.com/v3/mail/send"
+
+val client = HttpClient(CIO) {
+    install(Logging)
+    install(JsonFeature) {
+        serializer = GsonSerializer()
+    }
+}
+
+fun fromEmail(email: String): String? {
+    return when (email) {
+        "tilde@echo.uib.no" -> "Tilde"
+        "bedkom@echo.uib.no" -> "Bedkom"
+        "webkom@echo.uib.no" -> "Webkom"
+        "gnist@echo.uib.no" -> "Gnist"
+        else -> null
+    }
+}
+
+suspend fun sendEmail(
+    from: String,
+    to: String,
+    sendGridTemplate: SendGridTemplate,
+    template: Template,
+    sendGridApiKey: String
+) {
+    val fromName = fromEmail(from)
+    val fromPers =
+        if (fromName != null)
+            SendGridEmail(from, fromName)
+        else
+            SendGridEmail(from)
+
+    val templateId = when (template) {
+        Template.CONFIRM_REG -> "d-1fff3960b2184def9cf8bac082aeac21"
+        Template.CONFIRM_WAIT -> "d-1965cd803e6940c1a6724e3c53b70275"
+        Template.REGS_LINK -> "d-50e33549c29e46b7a6c871e97324ac5f"
     }
 
-    return true
+    val response: HttpResponse = client.post(SENDGRID_ENDPOINT) {
+        headers {
+            contentType(ContentType.Application.Json)
+            body = SendGridRequest(
+                listOf(
+                    SendGridPersonalization(
+                        to = listOf(SendGridEmail(to)),
+                        dynamic_template_data = sendGridTemplate
+                    )
+                ), from = fromPers, template_id = templateId
+            )
+            append(HttpHeaders.Authorization, "Bearer $sendGridApiKey")
+        }
+    }
+
+    if (response.status != HttpStatusCode.Accepted) {
+        throw IOException("Status code is not 202: ${response.status}, ${response.content}")
+    }
 }

--- a/src/test/kotlin/no/uib/echo/HappeningRegistrationTest.kt
+++ b/src/test/kotlin/no/uib/echo/HappeningRegistrationTest.kt
@@ -11,6 +11,8 @@ import io.ktor.server.testing.TestApplicationCall
 import io.ktor.server.testing.handleRequest
 import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import no.uib.echo.plugins.configureRouting
 import no.uib.echo.plugins.Routing
 import no.uib.echo.schema.*
@@ -119,14 +121,15 @@ class HappeningRegistrationTest : StringSpec({
                 Answer,
                 SpotRange
             )
-
-            for (t in be) {
-                insertOrUpdateHappening(exampleHappening1(t), null, false)
-                insertOrUpdateHappening(exampleHappening2(t), null, false)
-                insertOrUpdateHappening(exampleHappening3(t), null, false)
-                insertOrUpdateHappening(exampleHappening4(t), null, false)
-                insertOrUpdateHappening(exampleHappening5(t), null, false)
-                insertOrUpdateHappening(exampleHappening6(t), null, false)
+        }
+        for (t in be) {
+            withContext(Dispatchers.IO) {
+                insertOrUpdateHappening(exampleHappening1(t), false, null)
+                insertOrUpdateHappening(exampleHappening2(t), false, null)
+                insertOrUpdateHappening(exampleHappening3(t), false, null)
+                insertOrUpdateHappening(exampleHappening4(t), false, null)
+                insertOrUpdateHappening(exampleHappening5(t), false, null)
+                insertOrUpdateHappening(exampleHappening6(t), false, null)
             }
         }
     }


### PR DESCRIPTION
Byttet til templates som man lager inne på SendGrid.
SendGrid sin Java API er kronglete af om man skal bruke templates, så byttet til REST API'en deres i stedet (med Ktor Client).

# SendGrid sin Java API:

![](https://media4.giphy.com/media/3og0INAY5MLmEBubyU/giphy.gif)

# Ktor Client:
![](https://media3.giphy.com/media/d4blalI6x2oc4xAA/giphy.gif)