### PR TITLE
🗃️ Fix constraints of column names

### DIFF
--- a/src/main/kotlin/no/uib/echo/schema/Happening.kt
+++ b/src/main/kotlin/no/uib/echo/schema/Happening.kt
@@ -38,8 +38,8 @@ object Happening : Table() {
     val slug: Column<String> = text("slug").uniqueIndex()
     val happeningType: Column<String> = text("happening_type")
     val registrationDate: Column<DateTime> = datetime("registration_date")
-    val organizerEmail: Column<String?> = text("organizer_email").nullable()
-    val registrationsLink: Column<String> = text("registrations_link")
+    val organizerEmail: Column<String> = text("organizer_email")
+    val registrationsLink: Column<String?> = text("registrations_link").nullable()
 
     override val primaryKey: PrimaryKey = PrimaryKey(slug)
 }
@@ -59,7 +59,7 @@ fun selectHappening(slug: String): HappeningJson? {
             it[registrationDate].toString(),
             spotRanges,
             HAPPENING_TYPE.valueOf(it[Happening.happeningType]),
-            it[organizerEmail] ?: ""
+            it[organizerEmail]
         )
     }
 }

--- a/src/main/resources/db/migration/V8__Default_values.sql
+++ b/src/main/resources/db/migration/V8__Default_values.sql
@@ -1,0 +1,7 @@
+ALTER TABLE happening
+ALTER COLUMN organizer_email
+SET DEFAULT 'webkom@echo.uib.no';
+
+ALTER TABLE happening
+ALTER COLUMN organizer_email
+SET NOT NULL;


### PR DESCRIPTION
Både `organizer_email` og `registrations_link` er satt til `NULL` i databasen.

Denne PR'en fikser at
- `organizer_email` blir `NOT NULL` 
- `registrations_link` forblir `NULL`, men blir satt til `nullable()` i Kotlin sitt schema (sånn at schema og database er like)