### PR TITLE
🔧 Change to new URL for registrations lists

### DIFF
--- a/src/main/kotlin/no/uib/echo/schema/Happening.kt
+++ b/src/main/kotlin/no/uib/echo/schema/Happening.kt
@@ -123,7 +123,7 @@ suspend fun insertOrUpdateHappening(
                             newHappening.organizerEmail,
                             SendGridTemplate(
                                 newHappening.title ?: newHappening.slug,
-                                "https://echo-web-backend-prod/$registrationRoute/$registrationsLink",
+                                "https://echo.uib.no/$registrationRoute/$registrationsLink",
                                 hapTypeLiteral
                             ),
                             Template.REGS_LINK,


### PR DESCRIPTION
Nå kan de vises på frontend'en istedenfor backend'en.
Hører sammen med https://github.com/echo-webkom/echo-web-frontend/pull/816.