### PR TITLE
⬆️ Switch to JDK 17

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set up JDK 13
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '13'
+          java-version: '17'
           distribution: 'adopt'
 
       - name: Build with Gradle & Shadow

--- a/.github/workflows/ktlint.yaml
+++ b/.github/workflows/ktlint.yaml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set up JDK 13
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '13'
+          java-version: '17'
           distribution: 'adopt'
 
       - name: Run ktlint checks

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# We use OpenJDK 13 since that is what our Heroku instance uses.
+# We use OpenJDK 17 since that is what our Heroku instance uses.
 # Download Gradle wrapper and install dependencies.
-FROM openjdk:13-jdk-slim AS deps
+FROM openjdk:17-jdk-slim AS deps
 
 WORKDIR /opt/build
 
@@ -12,7 +12,7 @@ RUN ./gradlew installDist --build-cache --no-daemon
 
 
 # Build project with downloaded Gradle wrapper and cached dependencies.
-FROM openjdk:13-jdk-slim AS build
+FROM openjdk:17-jdk-slim AS build
 
 WORKDIR /opt/build
 
@@ -33,7 +33,7 @@ COPY src/test src/test
 
 
 # Run the server
-FROM openjdk:13-jdk-slim
+FROM openjdk:17-jdk-slim
 
 WORKDIR /opt/app
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,13 +104,13 @@ testlogger {
 
 // Set JVM target for Java.
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(13))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
 
 // Set JVM target for Kotlin.
 tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions {
-        jvmTarget = "13"
+        jvmTarget = "17"
     }
 }
 

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,1 @@
-java.runtime.version=13
+java.runtime.version=17


### PR DESCRIPTION
Java 13 (som vi bruker) får ikke updates lenger. Java 17 er den nye versjonen med LTS (long-term support).