### PR TITLE
🐛 Fix local build not working with docker compose 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,16 @@
-# Needed for backend
+# Needed for backend.
+# Application will not run at all without this.
 ADMIN_KEY=key_here
 
-# Needed for Cypress testing
+# Needed for Cypress testing.
+# Cypress tests will fail without these.
 SANITY_TOKEN=token_here
 SANITY_DATASET=dataset_here
 
-# Needed for sending emails
+# Needed for sending emails.
 SENDGRID_API_KEY=key_here
 
-# Optional feature toggles
+# Optional feature toggles.
+# These do not need to be defined.
 SEND_EMAIL_REGISTRATION=false   # default is false
 SEND_EMAIL_HAPPENING=true       # default is true 

--- a/docker-compose.cypress.yaml
+++ b/docker-compose.cypress.yaml
@@ -43,9 +43,9 @@ services:
     environment:
       DATABASE_URL: postgres://postgres:password@database/postgres
       # Value of DEV doesn't matter, only that it's defined.
-      DEV: "yes"
+      DEV: 'yes'
       # Values from .env file
-      ADMIN_KEY: ${ADMIN_KEY}
+      ADMIN_KEY: ${ADMIN_KEY:?Must specify ADMIN_KEY in .env file or environment.}
 
   database:
     # Postgres 13.4 is the version Heroku uses.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,9 +20,9 @@ services:
       DEV: 'yes'
       # Values from .env file
       ADMIN_KEY: ${ADMIN_KEY:?Must specify ADMIN_KEY in .env file or environment.}
-      SENDGRID_API_KEY: ${SENDGRID_API_KEY:?Must specify SENDGRID_API_KEY in .env file or environment.}
-      SEND_EMAIL_REGISTRATION: ${SEND_EMAIL_REGISTRATION:?Must specify SEND_EMAIL_REGISTRATION in .env file or environment.}
-      SEND_EMAIL_HAPPENING: ${SEND_EMAIL_HAPPENING:?Must specify SEND_EMAIL_HAPPENING in .env file or environment.}
+      SENDGRID_API_KEY:
+      SEND_EMAIL_REGISTRATION:
+      SEND_EMAIL_HAPPENING:
 
   database:
     # Postgres 13.4 is the version Heroku uses.

--- a/src/main/kotlin/no/uib/echo/Application.kt
+++ b/src/main/kotlin/no/uib/echo/Application.kt
@@ -64,8 +64,8 @@ fun Application.module() {
     val adminKey = environment.config.property("ktor.adminKey").getString()
     val databaseUrl = URI(environment.config.property("ktor.databaseUrl").getString())
     val mbMaxPoolSize = environment.config.propertyOrNull("ktor.maxPoolSize")?.getString()
-    val sendEmailReg = environment.config.property("ktor.sendEmailRegistration").getString().toBoolean()
-    val sendEmailHap = environment.config.property("ktor.sendEmailHappening").getString().toBoolean()
+    val sendEmailReg = environment.config.property("ktor.sendEmailRegistration").getString().toBooleanStrict()
+    val sendEmailHap = environment.config.property("ktor.sendEmailHappening").getString().toBooleanStrict()
     val maybeSendGridApiKey = environment.config.propertyOrNull("ktor.sendGridApiKey")?.getString()
     val sendGridApiKey = when (maybeSendGridApiKey.isNullOrEmpty()) {
         true -> null


### PR DESCRIPTION
Sto at man måtte definere `SENDGRID_API_KEY`, `SEND_EMAIL_HAPPENING` og `SEND_EMAIL_REGISTRATION` om man kjørte `docker-compose up --build` lokalt, dette skal ikke være nødvendig siden disse variablene er valgfrie.