### PR TITLE
Add waitlist as field at regcount endpoint

### DIFF
--- a/src/main/kotlin/no/uib/echo/plugins/Routing.kt
+++ b/src/main/kotlin/no/uib/echo/plugins/Routing.kt
@@ -719,7 +719,11 @@ object Routing {
                         Registration.happeningSlug eq it
                     }.count()
 
-                    RegistrationCountJson(it, count)
+                    val waitListCount = Registration.select {
+                        Registration.happeningSlug eq it and (Registration.waitList eq true)
+                    }.count()
+
+                    RegistrationCountJson(it, count, waitListCount)
                 }
             }
 

--- a/src/main/kotlin/no/uib/echo/schema/SpotRange.kt
+++ b/src/main/kotlin/no/uib/echo/schema/SpotRange.kt
@@ -45,7 +45,8 @@ data class SlugJson(
 @Serializable
 data class RegistrationCountJson(
     val slug: String,
-    val count: Long
+    val count: Long,
+    val waitListCount: Long
 )
 
 fun selectSpotRanges(slug: String): List<SpotRangeJson> {


### PR DESCRIPTION
I forhold til forsiden til frontenden så er tanken å vise antall på venteliste eller `Fullt` dersom noen er på venteliste slik at det ikke står 72/75 påmeldte, men når du trykker inn på arrangementet står det fullt.

Denne endringen legger til antall på venteliste i responsen, slik at det lett kan tolkes fra backend 😄 

Response vil da kunne se slik ut:
```json
[
    {
        "slug": "bedriftspresentasjon-med-bekk",
        "count": 3,
        "waitListCount": 2
    }
]
```